### PR TITLE
Add recommendation to use sbcl-1.4.6 for old quicklisp archive

### DIFF
--- a/05-Deploy/Deploy.re
+++ b/05-Deploy/Deploy.re
@@ -104,6 +104,15 @@ ql clack :latest                            # Clackのみ最新の登録バー�
 git lsx https://github.com/fukamachi/lsx    # LSXはgitリポジトリからダウンロードする
 //}
 
+@<list>{qlfile-example}に示した @<tt>{qlfile}を利用する場合は、2018/03/30にリリースされたsbcl-1.4.6を使用することが適切です。
+
+//cmd{
+# sbcl-1.4.6をダウンロード
+$ @<b>{ros install sbcl-bin/1.4.6}
+# sbcl-1.4.6を使用
+$ @<b>{ros use sbcl-bin/1.4.6}
+//}
+
 Qlotが有効な状態でCommon Lisp環境を起動するにはプロジェクトルートに移動し、実行コマンドの前に @<tt>{qlot exec} をつけます。たとえばREPLを起動するには @<tt>{qlot exec ros run} のようにします。LemでSLIMEを起動するときには @<tt>{C-u M-x slime} を実行して @<tt>{qlot/sbcl-bin/1.4.8} のように処理系名の前に @<tt>{qlot/} がついたものを選択します。
 
 QlotではRoswellスクリプトの対応もしています。qlfileによりインストールされる依存ライブラリのRoswellスクリプトは @<tt>{.qlot/bin/} の下にインストールされます。たとえば @<tt>{clack} の場合は @<tt>{.qlot/bin/clackup} がインストールされます。このスクリプトの実行に限り @<tt>{qlot exec} を省略してもQlotが有効な状態で実行されます。


### PR DESCRIPTION
2018/03/30で固定したqlfileに対して、現在の最新版である2.0.6を使っ
ていて嵌ったので、その注意を追加しました。